### PR TITLE
bug fix #13

### DIFF
--- a/src/ug_cmaplap/cmapLapParaInstancePool.h
+++ b/src/ug_cmaplap/cmapLapParaInstancePool.h
@@ -481,15 +481,13 @@ public:
          gzstream::igzstream &in
          )
    {
-      int n = 1;  // It has an instance added in constructer of LoadCoordinator
       auto basisElement = std::make_shared<BasisElement>();
       while( basisElement->read(comm,in) )
       {
-         if( insert(basisElement) ){ n++; }
+         insert(basisElement);
          basisElement = std::make_shared<BasisElement>();
       }
-      assert( n == static_cast<int>(size()) );
-      return n;
+      return size();
    }
 #endif
 

--- a/src/ug_cmaplap/cmapLapParaTaskMpi.cpp
+++ b/src/ug_cmaplap/cmapLapParaTaskMpi.cpp
@@ -390,6 +390,8 @@ CMapLapParaTaskMpi::bcast(
       )
 {
    UG::ParaCommMpi *commMpi = dynamic_cast< UG::ParaCommMpi* >(comm);
+   nRows = getBasis()->rows();
+   nCols = getBasis()->cols();
 
    if( iSolverType == static_cast<int>(Undefined) )
    {
@@ -598,6 +600,8 @@ CMapLapParaTaskMpi::send(
       )
 {
    CMapLapParaCommMpi *commMpi = dynamic_cast< CMapLapParaCommMpi* >(comm);
+   nRows = getBasis()->rows();
+   nCols = getBasis()->cols();
 
    iSolverType = static_cast<int>(solverType);
 


### PR DESCRIPTION
MPI versionでチェックポイントファイルからタスクを読み込んだ場合,
nRows, nColsが未定義の状態だったため、定義が必ず行うように修正